### PR TITLE
Correct deadlines for same type residence permit extension

### DIFF
--- a/bottle_app.py
+++ b/bottle_app.py
@@ -287,8 +287,16 @@ def _apply_post_processing_hacks(context, form_fields):
     # transition from YYYY-MM-DD dates to expected DD.MM.YYYY
     for date_key in [f["name"] for f in form_fields if f.get("type") == "date"]:
         if not context[date_key]:
-            # if date is not specified assume we need today's date
-            context[date_key] = datetime.datetime.now().strftime(DATETIME_HTML)
+            # XXX FIXME(ivasilev) Not perfect but the alternative is to introduce custom conditional logic in context
+            # templates, which seems like an overkill at the moment.
+            # In case it's about necinnostNto1 and same type permit extension before 01.07.2023, use 31.06.2023
+            # for application date
+            if (context.get("residence_permit_type") == "Prodloužení doby platnosti průkazu o povolení k pobytu (podání do 01.07.2023)" and
+                date_key == "application_date"):
+                context[date_key] = '31.06.2023'
+            else:
+                # if date is not specified assume we need today's date
+                context[date_key] = datetime.datetime.now().strftime(DATETIME_HTML)
         else:
             try:
                 context[date_key] = datetime.datetime.strptime(context[date_key], '%Y-%m-%d').strftime(DATETIME_HTML)

--- a/data/contexts/necinnost_Nin1_context.yaml
+++ b/data/contexts/necinnost_Nin1_context.yaml
@@ -32,10 +32,14 @@ document:
         after: "pro cizinku narozenou na území ČR"
 
   residence_deadline_map:
-      Extend:
-        name: "Prodloužení doby platnosti průkazu o povolení k pobytu"
+      Extend_before_01072023:
+        name: "Prodloužení doby platnosti průkazu o povolení k pobytu (podání do 01.07.2023)"
         deadline: "30 dnů"
         law: "§ 71 zákona č. 500/2004 Sb., správního řádu"
+      Extend:
+        name: "Prodloužení doby platnosti průkazu o povolení k pobytu"
+        deadline: "60 dnů"
+        law: "§ 169t odst. 7 písm. i) z. č. 326/1999 Sb"
       ZK:
         name: "Zaměstnanecká karta"
         deadline: "60 dnů ode dne podání žádosti, nebo 90 dnů ve zvlášť složitých případech, nebo pokud ministerstvo požádalo o vydání závazného stanoviska Úřad práce České republiky"
@@ -143,7 +147,6 @@ document:
       - name: application_number
         default: "OAM-424242"
       - name: application_date
-        default: "01.01.11"
         type: date
 
       - name: vady_zadosti
@@ -187,6 +190,7 @@ document:
       - name: residence_permit_type
         choices:
           - "Prodloužení doby platnosti průkazu o povolení k pobytu"
+          - "Prodloužení doby platnosti průkazu o povolení k pobytu (podání do 01.07.2023)"
           - "Zaměstnanecká karta"
           - "Modrá karta"
           - "Trvalý pobyt"

--- a/data/documents
+++ b/data/documents
@@ -7,7 +7,8 @@ documents:
       - value: "By law the deadlines for residence permits decisions are:"
       - type: list
         value:
-          - extending validity of any permit - 30 days
+          - extending validity of any permit - 60 days
+          - extending validity of any permit (before 01.07.2023) - 30 days
           - permanent residence permit application - 60 days
           - blue card application - 90 days
           - employee card application - 60 days (120 days in some cases)


### PR DESCRIPTION
Since 01.07.2023 deadline is 60 days. Although applications filed before 01.07.2023 have the old deadline of 30 days. Let's address this properly by allowing to generate 2 types of extension complaints.

Closes: #33