### PR TITLE
Update law reference after July, 1, 2023 changes

### DIFF
--- a/data/contexts/necinnost_Nin1_context.yaml
+++ b/data/contexts/necinnost_Nin1_context.yaml
@@ -39,7 +39,7 @@ document:
       Extend:
         name: "Prodloužení doby platnosti průkazu o povolení k pobytu"
         deadline: "60 dnů"
-        law: "§ 169t odst. 7 písm. i) z. č. 326/1999 Sb"
+        law: "§ 169t odst. 6 písm. i) z. č. 326/1999 Sb"
       ZK:
         name: "Zaměstnanecká karta"
         deadline: "60 dnů ode dne podání žádosti, nebo 90 dnů ve zvlášť složitých případech, nebo pokud ministerstvo požádalo o vydání závazného stanoviska Úřad práce České republiky"

--- a/data/contexts/necinnost_Nin1_context.yaml
+++ b/data/contexts/necinnost_Nin1_context.yaml
@@ -43,15 +43,15 @@ document:
       ZK:
         name: "Zaměstnanecká karta"
         deadline: "60 dnů ode dne podání žádosti, nebo 90 dnů ve zvlášť složitých případech, nebo pokud ministerstvo požádalo o vydání závazného stanoviska Úřad práce České republiky"
-        law: "§ 169t odst. 6 pism. c) z. č. 326/1999 Sb"
+        law: "§ 169t odst. 6 pism. d) z. č. 326/1999 Sb"
       MK:
         name: "Modrá karta"
         deadline: "90 dnů"
-        law: "§ 169t odst. 6 písm. d) z. č. 326/1999 Sb"
+        law: "§ 169t odst. 6 písm. e) z. č. 326/1999 Sb"
       TP:
         name: "Trvalý pobyt"
         deadline: "60 dnů"
-        law: "§ 169t odst. 6 písm. g) z. č. 326/1999 Sb"
+        law: "§ 169t odst. 6 písm. h) z. č. 326/1999 Sb"
       DP_study:
         name: "Dlouhodobý pobyt za účelem studia"
         deadline: "60 dnů"
@@ -75,7 +75,7 @@ document:
       PP:
         name: "Povolení k přechodnému pobytu"
         deadline: "60 dnů"
-        law: "§ 169t odst. 6 písm. f) z. č. 326/1999 Sb"
+        law: "§ 169t odst. 6 písm. g) z. č. 326/1999 Sb"
       DV_study:
         name: "Dlouhodobé vízum za účelem studia"
         deadline: "60 dnů"


### PR DESCRIPTION
Information on the OAMP website is obsolete and contains outdated references so let's consult the source and update law paragraphs. Changes to deadlines:
* Zamestnanecka karta d) ve lhůtě do 60 dnů ode dne podání žádosti o vydání zaměstnanecké karty;
* Modra karta e) ve lhůtě do 90 dnů ode dne podání žádosti o vydání modré karty;
* Prechodny pobyt g) ve lhůtě do 60 dnů ode dne podání žádosti o vydání povolení k přechodnému pobytu
* Trvaly pobyt h) v případě žádosti o vydání povolení k trvalému pobytu

Closes: #37